### PR TITLE
Don't print full response body to logs on POST error

### DIFF
--- a/src/main/java/com/hablapatabla/implingfinder/ImplingFinderWebManager.java
+++ b/src/main/java/com/hablapatabla/implingfinder/ImplingFinderWebManager.java
@@ -61,7 +61,7 @@ public class ImplingFinderWebManager {
                     public void onResponse(Call call, Response response) throws IOException {
                         try {
                             if (!response.isSuccessful())
-                                logger.error("On post response error " + response.body().string());
+                                logger.error("On post response error ");
                         }
                         catch (Exception e) {
                             logger.error("POST responded unsuccessful ", e);


### PR DESCRIPTION
Pretty quick one line change.

Closes #23, which was likely causing client OOMs/crashes and was certainly cluttering users' client logs, which makes providing them support a lot more difficult.